### PR TITLE
4.4.0 - enables switches task queueing to global/AWS SQS from (beanstalk-internal) Redis 

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -181,7 +181,7 @@ module "elastic_beanstalk_environment" {
       STATIC_AWS_S3_BUCKET             = module.cdn_static.s3_bucket
       STATIC_URL_BASE                  = "https://${local.static_alias}"
       UPLOAD_QUEUE_NAME                = local.upload_queue_name
-      UPLOAD_CELERY_BROKER_URL         = "sqs://${aws_iam_access_key.upload_queue_policy_access_key.id}:${aws_iam_access_key.upload_queue_policy_access_key.secret}@"
+      UPLOAD_CELERY_BROKER_URL         = "sqs://${aws_iam_access_key.upload_queue_user_access_key.id}:${aws_iam_access_key.upload_queue_user_access_key.secret}@"
     }
   )
 
@@ -390,10 +390,10 @@ resource "aws_iam_user_policy_attachment" "upload_queue_policy_attachment" {
 
 resource "aws_iam_user_policy_attachment" "upload_queue_sqs_shared_policy_attachment" {
   user       = aws_iam_user.upload_queue_user.name
-  policy_arn = aws_iam_policy.upload_queue_policy.arn
+  policy_arn = aws_iam_policy.sqs_shared_policy.arn
 }
 
-resource "aws_iam_access_key" "upload_queue_policy_access_key" {
+resource "aws_iam_access_key" "upload_queue_user_access_key" {
   user = aws_iam_user.upload_queue_user.name
 }
 

--- a/main.tf
+++ b/main.tf
@@ -324,14 +324,36 @@ resource "aws_iam_access_key" "static_upload_policy_access_key" {
 }
 
 
+
 ######
 # All things SQS
 ######
 
+
 locals {
+  sqs_shared_policy_name = "${local.namespace}-sqs-shared-policy"
   upload_queue_name        = "${local.namespace}-uploads.fifo"
   upload_queue_policy_name = "${local.namespace}-uploads-policy"
   upload_queue_user_name   = "${local.namespace}-uploads-user"
+}
+
+
+data "aws_iam_policy_document" "sqs_shared_policy" {
+  statement {
+    sid = "1"
+    actions = [
+      "sqs:ListQueues"
+    ]
+    resources = [
+      "*"
+    ]
+  }
+}
+
+resource "aws_iam_policy" "sqs_shared_policy" {
+  name   = local.sqs_shared_policy_name
+  path   = "/"
+  policy = data.aws_iam_policy_document.sqs_shared_policy.json
 }
 
 resource "aws_sqs_queue" "upload_queue" {
@@ -343,7 +365,7 @@ data "aws_iam_policy_document" "upload_queue_policy" {
   statement {
     sid = "1"
     actions = [
-      "sqs:DeleteMessage", "sqs:ListQueues", "sqs:ReceiveMessage", "sqs:SendMessage",
+      "sqs:DeleteMessage", "sqs:ReceiveMessage", "sqs:SendMessage",
     ]
     resources = [
       aws_sqs_queue.upload_queue.arn
@@ -362,6 +384,11 @@ resource "aws_iam_user" "upload_queue_user" {
 }
 
 resource "aws_iam_user_policy_attachment" "upload_queue_policy_attachment" {
+  user       = aws_iam_user.upload_queue_user.name
+  policy_arn = aws_iam_policy.upload_queue_policy.arn
+}
+
+resource "aws_iam_user_policy_attachment" "upload_queue_sqs_shared_policy_attachment" {
   user       = aws_iam_user.upload_queue_user.name
   policy_arn = aws_iam_policy.upload_queue_policy.arn
 }

--- a/main.tf
+++ b/main.tf
@@ -181,7 +181,7 @@ module "elastic_beanstalk_environment" {
       STATIC_AWS_S3_BUCKET             = module.cdn_static.s3_bucket
       STATIC_URL_BASE                  = "https://${local.static_alias}"
       UPLOAD_QUEUE_NAME                = local.upload_queue_name
-      UPLOAD_CELERY_BROKER_URL        = "sqs://${aws_iam_access_key.upload_queue_policy_access_key.id}:${aws_iam_access_key.upload_queue_policy_access_key.secret}@"
+      UPLOAD_CELERY_BROKER_URL         = "sqs://${aws_iam_access_key.upload_queue_policy_access_key.id}:${aws_iam_access_key.upload_queue_policy_access_key.secret}@"
     }
   )
 
@@ -343,7 +343,7 @@ data "aws_iam_policy_document" "upload_queue_policy" {
   statement {
     sid = "1"
     actions = [
-      "sqs:DeleteMessage", "sqs:ReceiveMessage", "sqs:SendMessage",
+      "sqs:DeleteMessage", "sqs:ListQueues", "sqs:ReceiveMessage", "sqs:SendMessage",
     ]
     resources = [
       aws_sqs_queue.upload_queue.arn

--- a/main.tf
+++ b/main.tf
@@ -342,6 +342,8 @@ data "aws_iam_policy_document" "sqs_shared_policy" {
   statement {
     sid = "1"
     actions = [
+      "sqs:GetQueueAttributes",
+      "sqs:GetQueueUrl",
       "sqs:ListQueues"
     ]
     resources = [

--- a/main.tf
+++ b/main.tf
@@ -180,7 +180,7 @@ module "elastic_beanstalk_environment" {
       STATIC_AWS_REGION                = var.aws_region,
       STATIC_AWS_S3_BUCKET             = module.cdn_static.s3_bucket
       STATIC_URL_BASE                  = "https://${local.static_alias}"
-      UPLOAD_QUEUE_NAME                = local.upload_queue_policy_name
+      UPLOAD_QUEUE_NAME                = local.upload_queue_name
       UPLOAD_CELERY_BROKER_URL        = "sqs://${aws_iam_access_key.upload_queue_policy_access_key.id}:${aws_iam_access_key.upload_queue_policy_access_key.secret}@"
     }
   )

--- a/main.tf
+++ b/main.tf
@@ -181,7 +181,7 @@ module "elastic_beanstalk_environment" {
       STATIC_AWS_S3_BUCKET             = module.cdn_static.s3_bucket
       STATIC_URL_BASE                  = "https://${local.static_alias}"
       UPLOAD_QUEUE_NAME                = local.upload_queue_name
-      UPLOAD_CELERY_BROKER_URL         = "sqs://${aws_iam_access_key.upload_queue_user_access_key.id}:${aws_iam_access_key.upload_queue_user_access_key.secret}@"
+      UPLOAD_CELERY_BROKER_URL         = "sqs://${urlencode(aws_iam_access_key.upload_queue_user_access_key.id)}:${urlencode(aws_iam_access_key.upload_queue_user_access_key.secret)}@"
     }
   )
 


### PR DESCRIPTION
## TLDR

This PR should be essentially complete and deployable, it just needs some additional testing.

TODO
 - [x] test on uscquestions.mentorpal.org instance (although now that site is broken because it's moving on with ECS changes)
 - [ ] test this on v2.mentorpal.org
 - [ ] merge to main and deploy also to careerfair.mentorpal.org
 - [ ] review and complete the subsequent PR about migration to ECS from Elastic Beanstalk

==================================================================


## Details 

This PR sets up the necessary infrastructure to migrate mentorpal to use global SQS as a task-queueing backend, replacing (elastic-beanstalk-internal) redis instances.

We use task queueing to trigger async worker jobs--training a mentor model, or processing an uploaded video.

From the code perspective, we use a python library, `celery` that abstracts away the actual queue implementation.

The app-version deployment that pairs with this infrastructure change to actually make the switch to SQS is [here](https://github.com/mentorpal/aws-beanstalk-app/pull/17)

...you'll notice that the changes in the app-version deployment seem to be just removing the old `CELERY_BROKER_URL` redis config from environment variables. That works because this terraform now sets those environment variable directly on the beanstalk instances, e.g. [here](https://github.com/mentorpal/aws-beanstalk-terraform/blob/0bb9cb8d64e81e519bc91c0d9ef94456dd1a934b/main.tf#L188)