### PR TITLE
Configure logs

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -170,16 +170,16 @@ module "elastic_beanstalk_environment" {
       GOOGLE_CLIENT_ID                 = var.google_client_id,
       JWT_SECRET                       = var.secret_jwt_key,
       MONGO_URI                        = var.secret_mongo_uri,
-      TRANSCRIBE_MODULE_PATH           = module.transcribe_aws.transcribe_env_vars.TRANSCRIBE_MODULE_PATH,
-      TRANSCRIBE_AWS_ACCESS_KEY_ID     = module.transcribe_aws.transcribe_env_vars.TRANSCRIBE_AWS_ACCESS_KEY_ID,
-      TRANSCRIBE_AWS_REGION            = var.aws_region,
-      TRANSCRIBE_AWS_SECRET_ACCESS_KEY = module.transcribe_aws.transcribe_env_vars.TRANSCRIBE_AWS_SECRET_ACCESS_KEY,
-      TRANSCRIBE_AWS_S3_BUCKET_SOURCE  = module.transcribe_aws.transcribe_env_vars.TRANSCRIBE_AWS_S3_BUCKET_SOURCE,
       STATIC_AWS_ACCESS_KEY_ID         = aws_iam_access_key.static_upload_policy_access_key.id,
       STATIC_AWS_SECRET_ACCESS_KEY     = aws_iam_access_key.static_upload_policy_access_key.secret,
       STATIC_AWS_REGION                = var.aws_region,
       STATIC_AWS_S3_BUCKET             = module.cdn_static.s3_bucket
       STATIC_URL_BASE                  = "https://${local.static_alias}"
+      TRANSCRIBE_MODULE_PATH           = module.transcribe_aws.transcribe_env_vars.TRANSCRIBE_MODULE_PATH,
+      TRANSCRIBE_AWS_ACCESS_KEY_ID     = module.transcribe_aws.transcribe_env_vars.TRANSCRIBE_AWS_ACCESS_KEY_ID,
+      TRANSCRIBE_AWS_REGION            = var.aws_region,
+      TRANSCRIBE_AWS_SECRET_ACCESS_KEY = module.transcribe_aws.transcribe_env_vars.TRANSCRIBE_AWS_SECRET_ACCESS_KEY,
+      TRANSCRIBE_AWS_S3_BUCKET_SOURCE  = module.transcribe_aws.transcribe_env_vars.TRANSCRIBE_AWS_S3_BUCKET_SOURCE,
     }
   )
 

--- a/vars.tf
+++ b/vars.tf
@@ -26,17 +26,17 @@ variable "eb_env_additional_settings" {
   }))
 
   description = "Additional Elastic Beanstalk setttings. For full list of options, see https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/command-options-general.html"
-  default     = [
-      {
-        namespace = "aws:elasticbeanstalk:environment:process:default"
-        name      = "StickinessEnabled"
-        value     = "false"
-      },
-      {
-        namespace = "aws:elasticbeanstalk:managedactions"
-        name      = "ManagedActionsEnabled"
-        value     = "false"
-      }
+  default = [
+    {
+      namespace = "aws:elasticbeanstalk:environment:process:default"
+      name      = "StickinessEnabled"
+      value     = "false"
+    },
+    {
+      namespace = "aws:elasticbeanstalk:managedactions"
+      name      = "ManagedActionsEnabled"
+      value     = "false"
+    }
   ]
 }
 
@@ -145,13 +145,13 @@ variable "eb_env_env_vars" {
 variable "eb_env_healthcheck_url" {
   type        = string
   description = "Application Health Check URL. Elastic Beanstalk will call this URL to check the health of the application running on EC2 instances"
-  default     = "/" 
+  default     = "/"
 }
 
 variable "eb_env_instance_type" {
   type        = string
   description = "Instances type"
-  default     = "t3.xlarge"  # between all the microservices needs at least 16GB memory
+  default     = "t3.xlarge" # between all the microservices needs at least 16GB memory
 }
 
 variable "eb_env_keypair" {
@@ -176,6 +176,42 @@ variable "eb_env_log_bucket_force_destroy" {
   type        = bool
   description = "Force destroy the S3 bucket for load balancer logs"
   default     = true
+}
+
+variable "eb_env_enable_stream_logs" {
+  type        = bool
+  default     = false
+  description = "Whether to create groups in CloudWatch Logs for proxy and deployment logs, and stream logs from each instance in your environment"
+}
+
+variable "eb_env_logs_delete_on_terminate" {
+  type        = bool
+  default     = false
+  description = "Whether to delete the log groups when the environment is terminated. If false, the logs are kept RetentionInDays days"
+}
+
+variable "eb_env_logs_retention_in_days" {
+  type        = number
+  default     = 30
+  description = "The number of days to keep log events before they expire."
+}
+
+variable "eb_env_health_streaming_enabled" {
+  type        = bool
+  default     = false
+  description = "For environments with enhanced health reporting enabled, whether to create a group in CloudWatch Logs for environment health and archive Elastic Beanstalk environment health data. For information about enabling enhanced health, see aws:elasticbeanstalk:healthreporting:system."
+}
+
+variable "eb_env_health_streaming_delete_on_terminate" {
+  type        = bool
+  default     = false
+  description = "Whether to delete the log group when the environment is terminated. If false, the health data is kept RetentionInDays days."
+}
+
+variable "eb_env_health_streaming_retention_in_days" {
+  type        = number
+  default     = 7
+  description = "The number of days to keep the archived health data before it expires."
 }
 
 variable "eb_env_name" {
@@ -277,19 +313,19 @@ variable "site_domain_name" {
 }
 
 variable "static_site_alias" {
-  type          = string
-  description   = "alias for static site that will serve video etc. By default, generates one based on site_domain_name"
-  default       = ""
+  type        = string
+  description = "alias for static site that will serve video etc. By default, generates one based on site_domain_name"
+  default     = ""
 }
 
 variable "static_cors_allowed_origins" {
-  type          = list(string)
-  description   = "list of cors allowed origins for static"
-  default       = []
+  type        = list(string)
+  description = "list of cors allowed origins for static"
+  default     = []
 }
 
 variable "vpc_cidr_block" {
   type        = string
   description = "cidr for the vpc, generally can leave the default unless there is conflict"
   default     = "172.16.0.0/16"
- }
+}


### PR DESCRIPTION
Non-breaking change, exposes [cloudposse/terraform-aws-elastic-beanstalk-environment](https://github.com/cloudposse/terraform-aws-elastic-beanstalk-environment) variables to configure logging. 