### PR TITLE
Firewall

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -326,7 +326,7 @@ resource "aws_lb_listener_rule" "redirect_http_to_https" {
 module "firewall" {
   source           = "./modules/waf"
   aws_region       = var.aws_region
-  environmen       = var.eb_env_stage
+  environment      = var.eb_env_stage
   top_level_domain = var.site_domain_name
   rate_limit       = 100
   tags             = var.eb_env_tags

--- a/main.tf
+++ b/main.tf
@@ -105,6 +105,7 @@ locals {
 ###
 # the cdn that serves videos from an s3 bucket, e.g. static.mentorpal.org
 ###
+
 module "cdn_static" {
   source               = "git::https://github.com/cloudposse/terraform-aws-cloudfront-s3-cdn?ref=tags/0.74.0"
   namespace            = "static-${var.eb_env_namespace}"
@@ -115,6 +116,9 @@ module "cdn_static" {
   dns_alias_enabled    = true
   parent_zone_name     = var.aws_route53_zone_name
   acm_certificate_arn  = data.aws_acm_certificate.cdn.arn
+  # bugfix: required for video playback after upload
+  forward_query_string    = true
+  query_string_cache_keys = ["v"]
 }
 
 # export s3 arn so serverless can pick it up to configure iam policies

--- a/main.tf
+++ b/main.tf
@@ -317,6 +317,27 @@ resource "aws_lb_listener_rule" "redirect_http_to_https" {
   }
 }
 
+#####
+# Firewall
+# 
+#####
+
+
+module "firewall" {
+  source           = "./modules/waf"
+  aws_region       = var.aws_region
+  environmen       = var.eb_env_stage
+  top_level_domain = var.site_domain_name
+  rate_limit       = 100
+  tags             = var.eb_env_tags
+}
+
+resource "aws_wafv2_web_acl_association" "load_blancer_firewall" {
+  resource_arn = module.elastic_beanstalk_environment.load_balancers[0]
+  web_acl_arn  = module.firewall.wafv2_webacl_arn
+}
+
+
 ######
 # Cloudwatch alarms
 # - https://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer-cloudwatch-metrics.html

--- a/modules/waf/main.tf
+++ b/modules/waf/main.tf
@@ -8,61 +8,6 @@ resource "aws_wafv2_web_acl" "wafv2_webacl" {
   }
 
   rule {
-    name     = "origin-header-rule"
-    priority = 1
-
-    action {
-      block {}
-    }
-
-    statement {
-      not_statement {
-        statement {
-          or_statement {
-            statement {
-              byte_match_statement {
-                search_string = var.top_level_domain
-                field_to_match {
-                  single_header {
-                    name = "origin"
-                  }
-                }
-                text_transformation {
-                  priority = 0
-                  type     = "LOWERCASE"
-                }
-                positional_constraint = "ENDS_WITH" # so that it covers subdomains
-              }
-            }
-
-            statement {
-              byte_match_statement {
-                search_string = "localhost"
-                field_to_match {
-                  single_header {
-                    name = "origin"
-                  }
-                }
-                text_transformation {
-                  priority = 0
-                  type     = "LOWERCASE"
-                }
-                positional_constraint = "CONTAINS" # so that it covers different port numbers
-              }
-            }
-          }
-        }
-      }
-    }
-
-    visibility_config {
-      cloudwatch_metrics_enabled = false
-      metric_name                = "origin-header-rule"
-      sampled_requests_enabled   = false
-    }
-  }
-
-  rule {
     name     = "ip-rate-limit-rule"
     priority = 2
 

--- a/modules/waf/main.tf
+++ b/modules/waf/main.tf
@@ -1,0 +1,212 @@
+resource "aws_wafv2_web_acl" "wafv2_webacl" {
+  name  = "mentorpal-${var.environment}-wafv2-webacl"
+  scope = "REGIONAL"
+  tags  = var.tags
+
+  default_action {
+    allow {}
+  }
+
+  rule {
+    name     = "origin-header-rule"
+    priority = 1
+
+    action {
+      block {}
+    }
+
+    statement {
+      not_statement {
+        statement {
+          or_statement {
+            statement {
+              byte_match_statement {
+                search_string = var.top_level_domain
+                field_to_match {
+                  single_header {
+                    name = "origin"
+                  }
+                }
+                text_transformation {
+                  priority = 0
+                  type     = "LOWERCASE"
+                }
+                positional_constraint = "ENDS_WITH" # so that it covers subdomains
+              }
+            }
+
+            statement {
+              byte_match_statement {
+                search_string = "localhost"
+                field_to_match {
+                  single_header {
+                    name = "origin"
+                  }
+                }
+                text_transformation {
+                  priority = 0
+                  type     = "LOWERCASE"
+                }
+                positional_constraint = "CONTAINS" # so that it covers different port numbers
+              }
+            }
+          }
+        }
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = false
+      metric_name                = "origin-header-rule"
+      sampled_requests_enabled   = false
+    }
+  }
+
+  rule {
+    name     = "ip-rate-limit-rule"
+    priority = 2
+
+    action {
+      block {}
+    }
+
+    statement {
+      rate_based_statement {
+        aggregate_key_type = "IP"
+        limit              = var.rate_limit
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = false
+      metric_name                = "${var.rate_limit}-ip-rate-limit-rule"
+      sampled_requests_enabled   = false
+    }
+  }
+
+  rule {
+    name     = "bot-control"
+    priority = 3
+
+    override_action {
+      # in order to test, lets just collect stats before enabling rules on prod:
+      count {}
+      # none {}
+    }
+    statement {
+      managed_rule_group_statement {
+        # see https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-list.html#aws-managed-rule-groups-bot
+        name        = "AWSManagedRulesBotControlRuleSet"
+        vendor_name = "AWS"
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "AWS-AWSBotControl-rule"
+      sampled_requests_enabled   = true
+    }
+  }
+
+  visibility_config {
+    cloudwatch_metrics_enabled = true
+    metric_name                = "mentorpal-${var.environment}-wafv2-webacl"
+    sampled_requests_enabled   = true
+  }
+}
+
+resource "aws_ssm_parameter" "origin_acl_arn" {
+  name  = "/mentorpal/${var.environment}/firewall/WEBACL_ARN"
+  type  = "String"
+  value = aws_wafv2_web_acl.wafv2_webacl.arn
+
+  tags = var.tags
+}
+
+resource "aws_s3_bucket" "s3_logs" {
+  bucket = "mentorpal-aws-waf-logs-${var.aws_region}-${var.environment}"
+  acl    = "private"
+  tags   = var.tags
+}
+
+data "aws_iam_policy_document" "policy_assume_kinesis" {
+  statement {
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["firehose.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "firehose_role" {
+  name               = "mentorpal-firehose-aws-waf-logs-${var.aws_region}-${var.environment}"
+  assume_role_policy = data.aws_iam_policy_document.policy_assume_kinesis.json
+  tags               = var.tags
+}
+
+# https://docs.aws.amazon.com/firehose/latest/dev/controlling-access.html#using-iam-s3
+data "aws_iam_policy_document" "s3_policy_document" {
+  statement {
+    sid = "1"
+    actions = [
+      "s3:GetBucketLocation",
+      "s3:ListBucket",
+      "s3:ListBucketMultipartUploads",
+    ]
+
+    resources = [
+      aws_s3_bucket.s3_logs.arn,
+    ]
+  }
+
+  statement {
+    sid = "2"
+    actions = [
+      "s3:AbortMultipartUpload",
+      "s3:GetObject",
+      "s3:PutObject",
+    ]
+
+    resources = [
+      "${aws_s3_bucket.s3_logs.arn}/*",
+    ]
+  }
+}
+
+resource "aws_iam_policy" "s3_policy" {
+  name   = "mentorpal-kinesis-s3-write-policy-${var.environment}"
+  policy = data.aws_iam_policy_document.s3_policy_document.json
+}
+
+resource "aws_iam_role_policy_attachment" "firehose_s3_policy_attachment" {
+  role       = aws_iam_role.firehose_role.name
+  policy_arn = aws_iam_policy.s3_policy.arn
+}
+
+resource "aws_kinesis_firehose_delivery_stream" "waf_logs_kinesis_stream" {
+  # the name must begin with aws-waf-logs-
+  name        = "aws-waf-logs-kinesis-stream-mentorpal-${var.environment}"
+  destination = "s3"
+  s3_configuration {
+    role_arn           = aws_iam_role.firehose_role.arn
+    bucket_arn         = aws_s3_bucket.s3_logs.arn
+    compression_format = "GZIP"
+  }
+  tags = var.tags
+}
+
+resource "aws_wafv2_web_acl_logging_configuration" "waf_logging_conf_staging" {
+  log_destination_configs = [aws_kinesis_firehose_delivery_stream.waf_logs_kinesis_stream.arn]
+  resource_arn            = aws_wafv2_web_acl.wafv2_webacl.arn
+  redacted_fields {
+    single_header {
+      name = "authorization"
+    }
+  }
+}
+
+output "wafv2_webacl_arn" {
+  value = aws_wafv2_web_acl.wafv2_webacl.arn
+}

--- a/modules/waf/vars.tf
+++ b/modules/waf/vars.tf
@@ -1,0 +1,21 @@
+variable "aws_region" {
+  type        = string
+  description = "AWS region"
+}
+
+variable "environment" {
+  type = string
+}
+variable "top_level_domain" {
+  type    = string
+  default = "mentorpal.org"
+}
+
+variable "tags" {
+  type = map(string)
+}
+
+variable "rate_limit" {
+  type    = number
+  default = 100 # minimum
+}

--- a/modules/waf/versions.tf
+++ b/modules/waf/versions.tf
@@ -1,0 +1,6 @@
+terraform {
+  required_version = ">= 0.15.0"
+  required_providers {
+    aws = ">= 3.1"
+  }
+}

--- a/versions.tf
+++ b/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.14.0"
+  required_version = ">= 0.15.0"
 
   required_providers {
     aws  = "~> 3.0"


### PR DESCRIPTION
planned changes:

```
Terraform used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  + create
  ~ update in-place
-/+ destroy and then create replacement
 <= read (data resources)

Terraform will perform the following actions:

  # module.mentorpal_beanstalk_deployment.aws_wafv2_web_acl_association.load_blancer_firewall will be created
  + resource "aws_wafv2_web_acl_association" "load_blancer_firewall" {
      + id           = (known after apply)
      + resource_arn = "arn:aws:elasticloadbalancing:us-east-1:639093085655:loadbalancer/app/awseb-AWSEB-VOWUCYPSTVMN/4f284a027a8bd555"
      + web_acl_arn  = (known after apply)
    }

  # module.mentorpal_beanstalk_deployment.module.elastic_beanstalk_environment.aws_elastic_beanstalk_environment.default will be updated in-place
  ~ resource "aws_elastic_beanstalk_environment" "default" {
        id                     = "e-xm5upkwdpt"
        name                   = "mentorpal-v2-mentorpal"
        tags                   = {
            "Stage" = "v2"
        }
        # (19 unchanged attributes hidden)

      ~ setting {
          # At least one attribute in this block is (or was) sensitive,
          # so its contents will not be displayed.
        }
    }

  # module.mentorpal_beanstalk_deployment.module.firewall.data.aws_iam_policy_document.s3_policy_document will be read during apply
  # (config refers to values not yet known)
 <= data "aws_iam_policy_document" "s3_policy_document"  {
      + id   = (known after apply)
      + json = (known after apply)

      + statement {
          + actions   = [
              + "s3:GetBucketLocation",
              + "s3:ListBucket",
              + "s3:ListBucketMultipartUploads",
            ]
          + resources = [
              + (known after apply),
            ]
          + sid       = "1"
        }
      + statement {
          + actions   = [
              + "s3:AbortMultipartUpload",
              + "s3:GetObject",
              + "s3:PutObject",
            ]
          + resources = [
              + (known after apply),
            ]
          + sid       = "2"
        }
    }

  # module.mentorpal_beanstalk_deployment.module.firewall.aws_iam_policy.s3_policy will be created
  + resource "aws_iam_policy" "s3_policy" {
      + arn       = (known after apply)
      + id        = (known after apply)
      + name      = "mentorpal-kinesis-s3-write-policy-v2"
      + path      = "/"
      + policy    = (known after apply)
      + policy_id = (known after apply)
      + tags_all  = (known after apply)
    }

  # module.mentorpal_beanstalk_deployment.module.firewall.aws_iam_role.firehose_role will be created
  + resource "aws_iam_role" "firehose_role" {
      + arn                   = (known after apply)
      + assume_role_policy    = jsonencode(
            {
              + Statement = [
                  + {
                      + Action    = "sts:AssumeRole"
                      + Effect    = "Allow"
                      + Principal = {
                          + Service = "firehose.amazonaws.com"
                        }
                      + Sid       = ""
                    },
                ]
              + Version   = "2012-10-17"
            }
        )
      + create_date           = (known after apply)
      + force_detach_policies = false
      + id                    = (known after apply)
      + managed_policy_arns   = (known after apply)
      + max_session_duration  = 3600
      + name                  = "mentorpal-firehose-aws-waf-logs-us-east-1-v2"
      + name_prefix           = (known after apply)
      + path                  = "/"
      + tags_all              = (known after apply)
      + unique_id             = (known after apply)

      + inline_policy {
          + name   = (known after apply)
          + policy = (known after apply)
        }
    }

  # module.mentorpal_beanstalk_deployment.module.firewall.aws_iam_role_policy_attachment.firehose_s3_policy_attachment will be created
  + resource "aws_iam_role_policy_attachment" "firehose_s3_policy_attachment" {
      + id         = (known after apply)
      + policy_arn = (known after apply)
      + role       = "mentorpal-firehose-aws-waf-logs-us-east-1-v2"
    }

  # module.mentorpal_beanstalk_deployment.module.firewall.aws_kinesis_firehose_delivery_stream.waf_logs_kinesis_stream will be created
  + resource "aws_kinesis_firehose_delivery_stream" "waf_logs_kinesis_stream" {
      + arn            = (known after apply)
      + destination    = "s3"
      + destination_id = (known after apply)
      + id             = (known after apply)
      + name           = "aws-waf-logs-kinesis-stream-mentorpal-v2"
      + tags_all       = (known after apply)
      + version_id     = (known after apply)

      + s3_configuration {
          + bucket_arn         = (known after apply)
          + buffer_interval    = 300
          + buffer_size        = 5
          + compression_format = "GZIP"
          + role_arn           = (known after apply)

          + cloudwatch_logging_options {
              + enabled         = (known after apply)
              + log_group_name  = (known after apply)
              + log_stream_name = (known after apply)
            }
        }
    }

  # module.mentorpal_beanstalk_deployment.module.firewall.aws_s3_bucket.s3_logs will be created
  + resource "aws_s3_bucket" "s3_logs" {
      + acceleration_status         = (known after apply)
      + acl                         = "private"
      + arn                         = (known after apply)
      + bucket                      = "mentorpal-aws-waf-logs-us-east-1-v2"
      + bucket_domain_name          = (known after apply)
      + bucket_regional_domain_name = (known after apply)
      + force_destroy               = false
      + hosted_zone_id              = (known after apply)
      + id                          = (known after apply)
      + region                      = (known after apply)
      + request_payer               = (known after apply)
      + tags_all                    = (known after apply)
      + website_domain              = (known after apply)
      + website_endpoint            = (known after apply)

      + versioning {
          + enabled    = (known after apply)
          + mfa_delete = (known after apply)
        }
    }

  # module.mentorpal_beanstalk_deployment.module.firewall.aws_ssm_parameter.origin_acl_arn will be created
  + resource "aws_ssm_parameter" "origin_acl_arn" {
      + arn       = (known after apply)
      + data_type = (known after apply)
      + id        = (known after apply)
      + key_id    = (known after apply)
      + name      = "/mentorpal/v2/firewall/WEBACL_ARN"
      + tags_all  = (known after apply)
      + tier      = "Standard"
      + type      = "String"
      + value     = (sensitive value)
      + version   = (known after apply)
    }

  # module.mentorpal_beanstalk_deployment.module.firewall.aws_wafv2_web_acl.wafv2_webacl will be created
  + resource "aws_wafv2_web_acl" "wafv2_webacl" {
      + arn        = (known after apply)
      + capacity   = (known after apply)
      + id         = (known after apply)
      + lock_token = (known after apply)
      + name       = "mentorpal-v2-wafv2-webacl"
      + scope      = "REGIONAL"
      + tags_all   = (known after apply)

      + default_action {
          + allow {
            }
        }

      + rule {
          + name     = "ip-rate-limit-rule"
          + priority = 2

          + action {

              + block {
                }
            }

          + statement {

              + rate_based_statement {
                  + aggregate_key_type = "IP"
                  + limit              = 100
                }
            }

          + visibility_config {
              + cloudwatch_metrics_enabled = false
              + metric_name                = "100-ip-rate-limit-rule"
              + sampled_requests_enabled   = false
            }
        }
      + rule {
          + name     = "origin-header-rule"
          + priority = 1

          + action {

              + block {
                }
            }

          + statement {

              + not_statement {
                  + statement {

                      + or_statement {
                          + statement {

                              + byte_match_statement {
                                  + positional_constraint = "ENDS_WITH"
                                  + search_string         = "v2.mentorpal.org"

                                  + field_to_match {

                                      + single_header {
                                          + name = "origin"
                                        }
                                    }

                                  + text_transformation {
                                      + priority = 0
                                      + type     = "LOWERCASE"
                                    }
                                }
                            }
                          + statement {

                              + byte_match_statement {
                                  + positional_constraint = "CONTAINS"
                                  + search_string         = "localhost"

                                  + field_to_match {

                                      + single_header {
                                          + name = "origin"
                                        }
                                    }

                                  + text_transformation {
                                      + priority = 0
                                      + type     = "LOWERCASE"
                                    }
                                }
                            }
                        }
                    }
                }
            }

          + visibility_config {
              + cloudwatch_metrics_enabled = false
              + metric_name                = "origin-header-rule"
              + sampled_requests_enabled   = false
            }
        }
      + rule {
          + name     = "bot-control"
          + priority = 3

          + override_action {
              + count {}
            }

          + statement {

              + managed_rule_group_statement {
                  + name        = "AWSManagedRulesBotControlRuleSet"
                  + vendor_name = "AWS"
                }
            }

          + visibility_config {
              + cloudwatch_metrics_enabled = true
              + metric_name                = "AWS-AWSBotControl-rule"
              + sampled_requests_enabled   = true
            }
        }

      + visibility_config {
          + cloudwatch_metrics_enabled = true
          + metric_name                = "mentorpal-v2-wafv2-webacl"
          + sampled_requests_enabled   = true
        }
    }

  # module.mentorpal_beanstalk_deployment.module.firewall.aws_wafv2_web_acl_logging_configuration.waf_logging_conf_staging will be created
  + resource "aws_wafv2_web_acl_logging_configuration" "waf_logging_conf_staging" {
      + id                      = (known after apply)
      + log_destination_configs = (known after apply)
      + resource_arn            = (known after apply)

      + redacted_fields {

          + single_header {
              + name = "authorization"
            }
        }
    }
```