### PR TITLE
fix 403 on page reloads

### DIFF
--- a/scripts/mentorpal-rewrite-default-index-s3-origin.js
+++ b/scripts/mentorpal-rewrite-default-index-s3-origin.js
@@ -22,15 +22,15 @@ function handler(event) {
     return response;
   }
 
-  if (uri == "/home" || uri == "/home/") {
-    request.uri = "/home/index.html";
+  // If the request is for a static file, return the file.
+  // otherwise return the index.html file.
+  // examples:
+  //  - /home -> /home/index.html
+  //  - /admin/file.js -> /admin/file.js
+  //  - /admin/record?videoId=8283ad00 -> /admin/index.html
+  if (!uri.includes(".")) {
+    request.uri = "/" + uri.split("/").filter(e=>e.length)[0] +"/index.html";
   }
-  if (uri == "/chat" || uri == "/chat/") {
-    request.uri = "/chat/index.html";
-  }
-  if (uri == "/admin" || uri == "/admin/") {
-    request.uri = "/admin/index.html";
-  }
-
+  
   return request;
 }


### PR DESCRIPTION
its because /admin/record is not a static asset, but
should return /admin/index.html and let client handle routing

Already deployed to newdev for testing. page reload on /admin/record now returns back to /admin